### PR TITLE
Implement an authentication macro, close #11

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -90,7 +90,7 @@ fn read_value(prompt: &str, hide_input: bool) -> String {
             if p1 == p2 {
                 return p1;
             } else {
-                println!("Passwords does not match, retry.");
+                println!("Passwords do not match, retry.");
             }
         }
     } else {
@@ -116,6 +116,7 @@ fn check_admin(pool: &Pool) -> ServiceResult<()> {
         });
 
     if !admin_with_password_exists {
+        println!("You seem to have started the server on an empty database. We'll now create the initial superuser.");
         let fullname = read_value("Fullname: ", false);
         let username = read_value("Username: ", false);
         let password = read_value("Password: ", true);

--- a/src/web/accounts.rs
+++ b/src/web/accounts.rs
@@ -1,6 +1,6 @@
 use crate::core::{Account, Money, Permission, Pool, Searchable, ServiceError, ServiceResult, authentication_password};
 use crate::login_required;
-use crate::web::identity_policy::{RetrievedAccount};
+use crate::web::identity_policy::RetrievedAccount;
 use crate::web::utils::{EmptyToNone, HbData, Search};
 use actix_web::{http, web, HttpRequest, HttpResponse};
 use handlebars::Handlebars;

--- a/src/web/accounts.rs
+++ b/src/web/accounts.rs
@@ -1,6 +1,6 @@
 use crate::core::{Account, Money, Permission, Pool, Searchable, ServiceError, ServiceResult, authentication_password};
 use crate::login_required;
-use crate::web::identity_policy::{LoggedAccount, RetrievedAccount};
+use crate::web::identity_policy::{RetrievedAccount};
 use crate::web::utils::{EmptyToNone, HbData, Search};
 use actix_web::{http, web, HttpRequest, HttpResponse};
 use handlebars::Handlebars;
@@ -125,7 +125,7 @@ pub async fn post_account_edit(
     account: web::Form<FormAccount>,
     account_id: web::Path<String>,
 ) -> ServiceResult<HttpResponse> {
-    let logged_account = login_required!(logged_account);
+    let _logged_account = login_required!(logged_account);
 
     if *account_id != account.id {
         return Err(ServiceError::BadRequest(
@@ -171,7 +171,7 @@ pub async fn post_account_create(
     logged_account: RetrievedAccount,
     account: web::Form<FormAccount>,
 ) -> ServiceResult<HttpResponse> {
-    let logged_account = login_required!(logged_account);
+    let _logged_account = login_required!(logged_account);
 
     let conn = &pool.get()?;
 
@@ -234,7 +234,7 @@ pub async fn delete_get(
     logged_account: RetrievedAccount,
     _account_id: web::Path<String>,
 ) -> ServiceResult<HttpResponse> {
-    let logged_account = login_required!(logged_account);
+    let _logged_account = login_required!(logged_account);
 
     println!("Delete is not supported!");
 

--- a/src/web/accounts.rs
+++ b/src/web/accounts.rs
@@ -1,6 +1,6 @@
 use crate::core::{Account, Money, Permission, Pool, Searchable, ServiceError, ServiceResult, authentication_password};
 use crate::login_required;
-use crate::web::identity_policy::LoggedAccount;
+use crate::web::identity_policy::{LoggedAccount, RetrievedAccount};
 use crate::web::utils::{EmptyToNone, HbData, Search};
 use actix_web::{http, web, HttpRequest, HttpResponse};
 use handlebars::Handlebars;
@@ -32,11 +32,11 @@ pub struct AuthenticationMethod {
 pub async fn get_accounts(
     pool: web::Data<Pool>,
     hb: web::Data<Handlebars>,
-    logged_account: LoggedAccount,
+    logged_account: RetrievedAccount,
     query: web::Query<Search>,
     request: HttpRequest,
 ) -> ServiceResult<HttpResponse> {
-    login_required!(logged_account);
+    let logged_account = login_required!(logged_account);
 
     let conn = &pool.get()?;
 
@@ -66,11 +66,11 @@ pub async fn get_accounts(
 pub async fn get_account_edit(
     pool: web::Data<Pool>,
     hb: web::Data<Handlebars>,
-    logged_account: LoggedAccount,
+    logged_account: RetrievedAccount,
     account_id: web::Path<String>,
     request: HttpRequest,
 ) -> ServiceResult<HttpResponse> {
-    login_required!(logged_account);
+    let logged_account = login_required!(logged_account);
 
     let conn = &pool.get()?;
 
@@ -121,11 +121,11 @@ pub async fn get_account_edit(
 /// POST route for `/account/{account_id}`
 pub async fn post_account_edit(
     pool: web::Data<Pool>,
-    logged_account: LoggedAccount,
+    logged_account: RetrievedAccount,
     account: web::Form<FormAccount>,
     account_id: web::Path<String>,
 ) -> ServiceResult<HttpResponse> {
-    login_required!(logged_account);
+    let logged_account = login_required!(logged_account);
 
     if *account_id != account.id {
         return Err(ServiceError::BadRequest(
@@ -153,10 +153,10 @@ pub async fn post_account_edit(
 /// GET route for `/account/create`
 pub async fn get_account_create(
     hb: web::Data<Handlebars>,
-    logged_account: LoggedAccount,
+    logged_account: RetrievedAccount,
     request: HttpRequest,
 ) -> ServiceResult<HttpResponse> {
-    login_required!(logged_account);
+    let logged_account = login_required!(logged_account);
 
     let body = HbData::new(&request)
         .with_account(logged_account)
@@ -168,10 +168,10 @@ pub async fn get_account_create(
 /// POST route for `/account/create`
 pub async fn post_account_create(
     pool: web::Data<Pool>,
-    logged_account: LoggedAccount,
+    logged_account: RetrievedAccount,
     account: web::Form<FormAccount>,
 ) -> ServiceResult<HttpResponse> {
-    login_required!(logged_account);
+    let logged_account = login_required!(logged_account);
 
     let conn = &pool.get()?;
 
@@ -194,7 +194,7 @@ pub async fn post_account_create(
 /// GET route for `/account/invite/{account_id}`
 pub async fn invite_get(
     pool: web::Data<Pool>,
-    logged_account: LoggedAccount,
+    logged_account: RetrievedAccount,
     account_id: web::Path<String>,
 ) -> ServiceResult<HttpResponse> {
     login_required!(logged_account);
@@ -212,7 +212,7 @@ pub async fn invite_get(
 /// GET route for `/account/revoke/{account_id}`
 pub async fn revoke_get(
     pool: web::Data<Pool>,
-    logged_account: LoggedAccount,
+    logged_account: RetrievedAccount,
     account_id: web::Path<String>,
 ) -> ServiceResult<HttpResponse> {
     login_required!(logged_account);
@@ -231,10 +231,10 @@ pub async fn revoke_get(
 /// GET route for `/account/delete/{account_id}`
 pub async fn delete_get(
     _hb: web::Data<Handlebars>,
-    logged_account: LoggedAccount,
+    logged_account: RetrievedAccount,
     _account_id: web::Path<String>,
 ) -> ServiceResult<HttpResponse> {
-    login_required!(logged_account);
+    let logged_account = login_required!(logged_account);
 
     println!("Delete is not supported!");
 

--- a/src/web/accounts.rs
+++ b/src/web/accounts.rs
@@ -1,4 +1,7 @@
-use crate::core::{Account, Money, Permission, Pool, Searchable, ServiceError, ServiceResult, authentication_password};
+use crate::core::{
+    authentication_password, Account, Money, Permission, Pool, Searchable, ServiceError,
+    ServiceResult,
+};
 use crate::login_required;
 use crate::web::identity_policy::RetrievedAccount;
 use crate::web::utils::{EmptyToNone, HbData, Search};

--- a/src/web/accounts.rs
+++ b/src/web/accounts.rs
@@ -1,13 +1,9 @@
-use actix_web::{http, web, HttpRequest, HttpResponse};
-use handlebars::Handlebars;
-
-use crate::core::{
-    authentication_password, Account, Money, Permission, Pool, Searchable, ServiceError,
-    ServiceResult,
-};
+use crate::core::{Account, Money, Permission, Pool, Searchable, ServiceError, ServiceResult, authentication_password};
+use crate::login_required;
 use crate::web::identity_policy::LoggedAccount;
 use crate::web::utils::{EmptyToNone, HbData, Search};
-
+use actix_web::{http, web, HttpRequest, HttpResponse};
+use handlebars::Handlebars;
 use uuid::Uuid;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -40,7 +36,7 @@ pub async fn get_accounts(
     query: web::Query<Search>,
     request: HttpRequest,
 ) -> ServiceResult<HttpResponse> {
-    logged_account.require_member()?;
+    login_required!(logged_account);
 
     let conn = &pool.get()?;
 
@@ -74,7 +70,7 @@ pub async fn get_account_edit(
     account_id: web::Path<String>,
     request: HttpRequest,
 ) -> ServiceResult<HttpResponse> {
-    logged_account.require_member()?;
+    login_required!(logged_account);
 
     let conn = &pool.get()?;
 
@@ -129,7 +125,7 @@ pub async fn post_account_edit(
     account: web::Form<FormAccount>,
     account_id: web::Path<String>,
 ) -> ServiceResult<HttpResponse> {
-    logged_account.require_member()?;
+    login_required!(logged_account);
 
     if *account_id != account.id {
         return Err(ServiceError::BadRequest(
@@ -160,7 +156,7 @@ pub async fn get_account_create(
     logged_account: LoggedAccount,
     request: HttpRequest,
 ) -> ServiceResult<HttpResponse> {
-    logged_account.require_member()?;
+    login_required!(logged_account);
 
     let body = HbData::new(&request)
         .with_account(logged_account)
@@ -175,7 +171,7 @@ pub async fn post_account_create(
     logged_account: LoggedAccount,
     account: web::Form<FormAccount>,
 ) -> ServiceResult<HttpResponse> {
-    logged_account.require_member()?;
+    login_required!(logged_account);
 
     let conn = &pool.get()?;
 
@@ -201,7 +197,7 @@ pub async fn invite_get(
     logged_account: LoggedAccount,
     account_id: web::Path<String>,
 ) -> ServiceResult<HttpResponse> {
-    logged_account.require_member()?;
+    login_required!(logged_account);
 
     let conn = &pool.get()?;
 
@@ -219,7 +215,7 @@ pub async fn revoke_get(
     logged_account: LoggedAccount,
     account_id: web::Path<String>,
 ) -> ServiceResult<HttpResponse> {
-    logged_account.require_member()?;
+    login_required!(logged_account);
 
     let conn = &pool.get()?;
 
@@ -238,7 +234,7 @@ pub async fn delete_get(
     logged_account: LoggedAccount,
     _account_id: web::Path<String>,
 ) -> ServiceResult<HttpResponse> {
-    logged_account.require_member()?;
+    login_required!(logged_account);
 
     println!("Delete is not supported!");
 

--- a/src/web/categories.rs
+++ b/src/web/categories.rs
@@ -1,6 +1,6 @@
 use crate::core::{Category, Money, Pool, Searchable, ServiceError, ServiceResult};
 use crate::login_required;
-use crate::web::identity_policy::{LoggedAccount, RetrievedAccount};
+use crate::web::identity_policy::{RetrievedAccount};
 use crate::web::utils::{HbData, Search};
 use actix_web::{http, web, HttpRequest, HttpResponse};
 use handlebars::Handlebars;
@@ -83,7 +83,7 @@ pub async fn post_category_edit(
     category: web::Form<FormCategory>,
     category_id: web::Path<String>,
 ) -> ServiceResult<HttpResponse> {
-    let logged_account = login_required!(logged_account);
+    let _logged_account = login_required!(logged_account);
 
     if *category_id != category.id {
         return Err(ServiceError::BadRequest(
@@ -146,7 +146,7 @@ pub async fn post_category_create(
     pool: web::Data<Pool>,
     category: web::Form<FormCategory>,
 ) -> ServiceResult<HttpResponse> {
-    let logged_account = login_required!(logged_account);
+    let _logged_account = login_required!(logged_account);
 
     let conn = &pool.get()?;
 
@@ -174,7 +174,7 @@ pub async fn get_category_delete(
     logged_account: RetrievedAccount,
     _category_id: web::Path<String>,
 ) -> ServiceResult<HttpResponse> {
-    let logged_account = login_required!(logged_account);
+    let _logged_account = login_required!(logged_account);
 
     println!("Delete is not supported!");
 

--- a/src/web/categories.rs
+++ b/src/web/categories.rs
@@ -1,11 +1,10 @@
+use crate::core::{Category, Money, Pool, Searchable, ServiceError, ServiceResult};
+use crate::login_required;
+use crate::web::identity_policy::LoggedAccount;
+use crate::web::utils::{HbData, Search};
 use actix_web::{http, web, HttpRequest, HttpResponse};
 use handlebars::Handlebars;
 use std::collections::HashMap;
-
-use crate::core::{Category, Money, Pool, Searchable, ServiceError, ServiceResult};
-use crate::web::identity_policy::LoggedAccount;
-use crate::web::utils::{HbData, Search};
-
 use uuid::Uuid;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -29,7 +28,7 @@ pub async fn get_categories(
     query: web::Query<Search>,
     request: HttpRequest,
 ) -> ServiceResult<HttpResponse> {
-    logged_account.require_member()?;
+    login_required!(logged_account);
 
     let conn = &pool.get()?;
 
@@ -63,7 +62,7 @@ pub async fn get_category_edit(
     category_id: web::Path<String>,
     request: HttpRequest,
 ) -> ServiceResult<HttpResponse> {
-    logged_account.require_member()?;
+    login_required!(logged_account);
 
     let conn = &pool.get()?;
 
@@ -84,7 +83,7 @@ pub async fn post_category_edit(
     category: web::Form<FormCategory>,
     category_id: web::Path<String>,
 ) -> ServiceResult<HttpResponse> {
-    logged_account.require_member()?;
+    login_required!(logged_account);
 
     if *category_id != category.id {
         return Err(ServiceError::BadRequest(
@@ -132,7 +131,7 @@ pub async fn get_category_create(
     logged_account: LoggedAccount,
     request: HttpRequest,
 ) -> ServiceResult<HttpResponse> {
-    logged_account.require_member()?;
+    login_required!(logged_account);
 
     let body = HbData::new(&request)
         .with_account(logged_account)
@@ -147,7 +146,7 @@ pub async fn post_category_create(
     pool: web::Data<Pool>,
     category: web::Form<FormCategory>,
 ) -> ServiceResult<HttpResponse> {
-    logged_account.require_member()?;
+    login_required!(logged_account);
 
     let conn = &pool.get()?;
 
@@ -175,7 +174,7 @@ pub async fn get_category_delete(
     logged_account: LoggedAccount,
     _category_id: web::Path<String>,
 ) -> ServiceResult<HttpResponse> {
-    logged_account.require_member()?;
+    login_required!(logged_account);
 
     println!("Delete is not supported!");
 

--- a/src/web/categories.rs
+++ b/src/web/categories.rs
@@ -1,6 +1,6 @@
 use crate::core::{Category, Money, Pool, Searchable, ServiceError, ServiceResult};
 use crate::login_required;
-use crate::web::identity_policy::{RetrievedAccount};
+use crate::web::identity_policy::RetrievedAccount;
 use crate::web::utils::{HbData, Search};
 use actix_web::{http, web, HttpRequest, HttpResponse};
 use handlebars::Handlebars;

--- a/src/web/categories.rs
+++ b/src/web/categories.rs
@@ -1,6 +1,6 @@
 use crate::core::{Category, Money, Pool, Searchable, ServiceError, ServiceResult};
 use crate::login_required;
-use crate::web::identity_policy::LoggedAccount;
+use crate::web::identity_policy::{LoggedAccount, RetrievedAccount};
 use crate::web::utils::{HbData, Search};
 use actix_web::{http, web, HttpRequest, HttpResponse};
 use handlebars::Handlebars;
@@ -23,12 +23,12 @@ pub struct FormCategory {
 /// GET route for `/categories`
 pub async fn get_categories(
     hb: web::Data<Handlebars>,
-    logged_account: LoggedAccount,
+    logged_account: RetrievedAccount,
     pool: web::Data<Pool>,
     query: web::Query<Search>,
     request: HttpRequest,
 ) -> ServiceResult<HttpResponse> {
-    login_required!(logged_account);
+    let logged_account = login_required!(logged_account);
 
     let conn = &pool.get()?;
 
@@ -57,12 +57,12 @@ pub async fn get_categories(
 /// GET route for `/category/{category_id}`
 pub async fn get_category_edit(
     hb: web::Data<Handlebars>,
-    logged_account: LoggedAccount,
+    logged_account: RetrievedAccount,
     pool: web::Data<Pool>,
     category_id: web::Path<String>,
     request: HttpRequest,
 ) -> ServiceResult<HttpResponse> {
-    login_required!(logged_account);
+    let logged_account = login_required!(logged_account);
 
     let conn = &pool.get()?;
 
@@ -78,12 +78,12 @@ pub async fn get_category_edit(
 
 /// POST route for `/category/{category_id}`
 pub async fn post_category_edit(
-    logged_account: LoggedAccount,
+    logged_account: RetrievedAccount,
     pool: web::Data<Pool>,
     category: web::Form<FormCategory>,
     category_id: web::Path<String>,
 ) -> ServiceResult<HttpResponse> {
-    login_required!(logged_account);
+    let logged_account = login_required!(logged_account);
 
     if *category_id != category.id {
         return Err(ServiceError::BadRequest(
@@ -128,10 +128,10 @@ pub async fn post_category_edit(
 /// GET route for `/category/create`
 pub async fn get_category_create(
     hb: web::Data<Handlebars>,
-    logged_account: LoggedAccount,
+    logged_account: RetrievedAccount,
     request: HttpRequest,
 ) -> ServiceResult<HttpResponse> {
-    login_required!(logged_account);
+    let logged_account = login_required!(logged_account);
 
     let body = HbData::new(&request)
         .with_account(logged_account)
@@ -142,11 +142,11 @@ pub async fn get_category_create(
 
 /// POST route for `/category/create`
 pub async fn post_category_create(
-    logged_account: LoggedAccount,
+    logged_account: RetrievedAccount,
     pool: web::Data<Pool>,
     category: web::Form<FormCategory>,
 ) -> ServiceResult<HttpResponse> {
-    login_required!(logged_account);
+    let logged_account = login_required!(logged_account);
 
     let conn = &pool.get()?;
 
@@ -171,10 +171,10 @@ pub async fn post_category_create(
 /// GET route for `/category/delete/{category_id}`
 pub async fn get_category_delete(
     _hb: web::Data<Handlebars>,
-    logged_account: LoggedAccount,
+    logged_account: RetrievedAccount,
     _category_id: web::Path<String>,
 ) -> ServiceResult<HttpResponse> {
-    login_required!(logged_account);
+    let logged_account = login_required!(logged_account);
 
     println!("Delete is not supported!");
 

--- a/src/web/identity_policy.rs
+++ b/src/web/identity_policy.rs
@@ -11,7 +11,7 @@ use futures::prelude::*;
 use uuid::Uuid;
 
 use crate::core::{
-    Account, DbConnection, Permission, Pool, ServiceError, ServiceResult, Session, AUTH_COOKIE_NAME,
+    Account, DbConnection, Pool, ServiceError, ServiceResult, Session, AUTH_COOKIE_NAME,
 };
 
 // Encryption key for cookies
@@ -23,7 +23,7 @@ static ref SECRET_KEY: String = std::env::var("SECRET_KEY").unwrap_or_else(|_| "
 macro_rules! login_required {
     ($account:ident) => {
         if let RetrievedAccount::Acc(acc) = $account {
-            // if a logged sccount has been retrieved successfully, check its validity
+            // if a logged account has been retrieved successfully, check its validity
             match acc.account.permission {
                 crate::core::Permission::ADMIN | crate::core::Permission::MEMBER => acc,
                 _ => {
@@ -45,14 +45,14 @@ macro_rules! login_required {
 macro_rules! admin_required {
     ($account:ident) => {
         if let RetrievedAccount::Acc(acc) = $account {
-            // if a logged sccount has been retrieved successfully, check its validity
+            // if a logged account has been retrieved successfully, check its validity
             match acc.account.permission {
                 crate::core::Permission::ADMIN => acc,
                 crate::core::Permission::MEMBER => {
                     // TODO: Better handling for unauthorized errors
                     return Ok(HttpResponse::Found()
                         .header(http::header::LOCATION, "/login")
-                        .finish())
+                        .finish());
                 }
                 _ => {
                     return Ok(HttpResponse::Found()

--- a/src/web/identity_policy.rs
+++ b/src/web/identity_policy.rs
@@ -244,14 +244,4 @@ impl LoggedAccount {
 
         Ok(())
     }
-
-    // TODO: Port as macro
-    /// Check if the account has admin rights. Otherwise return `ServiceError`
-    pub fn require_admin(&self) -> ServiceResult<()> {
-        match self.account.permission {
-            Permission::ADMIN => Ok(()),
-            Permission::MEMBER => Err(ServiceError::InsufficientPrivileges),
-            _ => Err(ServiceError::Unauthorized),
-        }
-    }
 }

--- a/src/web/index.rs
+++ b/src/web/index.rs
@@ -1,7 +1,7 @@
 use actix_identity::Identity;
 use actix_web::{http, web, HttpRequest, HttpResponse};
 use handlebars::Handlebars;
-
+use crate::login_required;
 use crate::core::{authentication_password, stats, Pool, ServiceResult};
 use crate::web::identity_policy::LoggedAccount;
 use crate::web::utils::HbData;
@@ -26,6 +26,8 @@ pub async fn get_index(
     logged_account: LoggedAccount,
     request: HttpRequest,
 ) -> ServiceResult<HttpResponse> {
+    login_required!(logged_account);
+
     let conn = &pool.get()?;
 
     let total = stats::get_total_balance(&conn)?;

--- a/src/web/index.rs
+++ b/src/web/index.rs
@@ -1,10 +1,10 @@
+use crate::core::{authentication_password, stats, Pool, ServiceResult};
+use crate::login_required;
+use crate::web::identity_policy::{LoggedAccount, RetrievedAccount};
+use crate::web::utils::HbData;
 use actix_identity::Identity;
 use actix_web::{http, web, HttpRequest, HttpResponse};
 use handlebars::Handlebars;
-use crate::login_required;
-use crate::core::{authentication_password, stats, Pool, ServiceResult};
-use crate::web::identity_policy::{LoggedAccount, RetrievedAccount};
-use crate::web::utils::HbData;
 
 #[derive(Serialize, Deserialize)]
 pub struct LoginForm {
@@ -24,7 +24,7 @@ pub async fn get_index(
     pool: web::Data<Pool>,
     hb: web::Data<Handlebars>,
     logged_account: RetrievedAccount,
-    request: HttpRequest
+    request: HttpRequest,
 ) -> ServiceResult<HttpResponse> {
     let logged_account = login_required!(logged_account);
 

--- a/src/web/products.rs
+++ b/src/web/products.rs
@@ -1,6 +1,7 @@
 use crate::core::{
     Category, DbConnection, Money, Pool, Product, Searchable, ServiceError, ServiceResult,
 };
+use crate::login_required;
 use crate::web::identity_policy::LoggedAccount;
 use crate::web::utils::{HbData, Search};
 use actix_multipart::Multipart;
@@ -34,7 +35,7 @@ pub async fn get_products(
     query: web::Query<Search>,
     request: HttpRequest,
 ) -> ServiceResult<HttpResponse> {
-    logged_account.require_member()?;
+    login_required!(logged_account);
 
     let conn = &pool.get()?;
 
@@ -68,7 +69,7 @@ pub async fn get_product_edit(
     product_id: web::Path<String>,
     request: HttpRequest,
 ) -> ServiceResult<HttpResponse> {
-    logged_account.require_member()?;
+    login_required!(logged_account);
 
     let conn = &pool.get()?;
 
@@ -92,7 +93,7 @@ pub async fn post_product_edit(
     product: web::Form<FormProduct>,
     product_id: web::Path<String>,
 ) -> ServiceResult<HttpResponse> {
-    logged_account.require_member()?;
+    login_required!(logged_account);
 
     if *product_id != product.id {
         return Err(ServiceError::BadRequest(
@@ -148,7 +149,7 @@ pub async fn get_product_create(
     pool: web::Data<Pool>,
     request: HttpRequest,
 ) -> ServiceResult<HttpResponse> {
-    logged_account.require_member()?;
+    login_required!(logged_account);
     let conn = &pool.get()?;
 
     let all_categories = Category::all(&conn)?;
@@ -167,7 +168,7 @@ pub async fn post_product_create(
     pool: web::Data<Pool>,
     product: web::Form<FormProduct>,
 ) -> ServiceResult<HttpResponse> {
-    logged_account.require_member()?;
+    login_required!(logged_account);
 
     let conn = &pool.get()?;
 
@@ -201,7 +202,7 @@ pub async fn get_product_delete(
     logged_account: LoggedAccount,
     _product_id: web::Path<String>,
 ) -> ServiceResult<HttpResponse> {
-    logged_account.require_member()?;
+    login_required!(logged_account);
 
     println!("Delete is not supported!");
 
@@ -216,7 +217,7 @@ pub async fn get_product_remove_image(
     logged_account: LoggedAccount,
     product_id: web::Path<String>,
 ) -> ServiceResult<HttpResponse> {
-    logged_account.require_member()?;
+    login_required!(logged_account);
 
     let conn = &pool.get()?;
 
@@ -236,7 +237,7 @@ pub async fn post_product_upload_image(
     product_id: web::Path<String>,
     multipart: Multipart,
 ) -> ServiceResult<HttpResponse> {
-    logged_account.require_member()?;
+    login_required!(logged_account);
 
     let conn = &pool.get()?;
     let mut product = Product::get(&conn, &Uuid::parse_str(&product_id)?)?;

--- a/src/web/products.rs
+++ b/src/web/products.rs
@@ -2,7 +2,7 @@ use crate::core::{
     Category, DbConnection, Money, Pool, Product, Searchable, ServiceError, ServiceResult,
 };
 use crate::login_required;
-use crate::web::identity_policy::LoggedAccount;
+use crate::web::identity_policy::{LoggedAccount, RetrievedAccount};
 use crate::web::utils::{HbData, Search};
 use actix_multipart::Multipart;
 use actix_web::{http, web, HttpRequest, HttpResponse};
@@ -30,12 +30,12 @@ pub struct FormProduct {
 /// GET route for `/products`
 pub async fn get_products(
     hb: web::Data<Handlebars>,
-    logged_account: LoggedAccount,
+    logged_account: RetrievedAccount,
     pool: web::Data<Pool>,
     query: web::Query<Search>,
     request: HttpRequest,
 ) -> ServiceResult<HttpResponse> {
-    login_required!(logged_account);
+    let logged_account = login_required!(logged_account);
 
     let conn = &pool.get()?;
 
@@ -64,12 +64,12 @@ pub async fn get_products(
 /// GET route for `/product/{product_id}`
 pub async fn get_product_edit(
     hb: web::Data<Handlebars>,
-    logged_account: LoggedAccount,
+    logged_account: RetrievedAccount,
     pool: web::Data<Pool>,
     product_id: web::Path<String>,
     request: HttpRequest,
 ) -> ServiceResult<HttpResponse> {
-    login_required!(logged_account);
+    let logged_account = login_required!(logged_account);
 
     let conn = &pool.get()?;
 
@@ -88,12 +88,12 @@ pub async fn get_product_edit(
 
 /// POST route for `/product/{product_id}`
 pub async fn post_product_edit(
-    logged_account: LoggedAccount,
+    logged_account: RetrievedAccount,
     pool: web::Data<Pool>,
     product: web::Form<FormProduct>,
     product_id: web::Path<String>,
 ) -> ServiceResult<HttpResponse> {
-    login_required!(logged_account);
+    let logged_account = login_required!(logged_account);
 
     if *product_id != product.id {
         return Err(ServiceError::BadRequest(
@@ -145,11 +145,11 @@ pub async fn post_product_edit(
 /// GET route for `/product/create`
 pub async fn get_product_create(
     hb: web::Data<Handlebars>,
-    logged_account: LoggedAccount,
+    logged_account: RetrievedAccount,
     pool: web::Data<Pool>,
     request: HttpRequest,
 ) -> ServiceResult<HttpResponse> {
-    login_required!(logged_account);
+    let logged_account = login_required!(logged_account);
     let conn = &pool.get()?;
 
     let all_categories = Category::all(&conn)?;
@@ -164,11 +164,11 @@ pub async fn get_product_create(
 
 /// POST route for `/product/create`
 pub async fn post_product_create(
-    logged_account: LoggedAccount,
+    logged_account: RetrievedAccount,
     pool: web::Data<Pool>,
     product: web::Form<FormProduct>,
 ) -> ServiceResult<HttpResponse> {
-    login_required!(logged_account);
+    let logged_account = login_required!(logged_account);
 
     let conn = &pool.get()?;
 
@@ -199,10 +199,10 @@ pub async fn post_product_create(
 /// GET route for `/product/delete/{product_id}`
 pub async fn get_product_delete(
     _hb: web::Data<Handlebars>,
-    logged_account: LoggedAccount,
+    logged_account: RetrievedAccount,
     _product_id: web::Path<String>,
 ) -> ServiceResult<HttpResponse> {
-    login_required!(logged_account);
+    let logged_account = login_required!(logged_account);
 
     println!("Delete is not supported!");
 
@@ -214,10 +214,10 @@ pub async fn get_product_delete(
 /// GET route for `/product/remove-image/{product_id}`
 pub async fn get_product_remove_image(
     pool: web::Data<Pool>,
-    logged_account: LoggedAccount,
+    logged_account: RetrievedAccount,
     product_id: web::Path<String>,
 ) -> ServiceResult<HttpResponse> {
-    login_required!(logged_account);
+    let logged_account = login_required!(logged_account);
 
     let conn = &pool.get()?;
 
@@ -233,11 +233,11 @@ pub async fn get_product_remove_image(
 /// POST route for `/product/upload-image/{product_id}`
 pub async fn post_product_upload_image(
     pool: web::Data<Pool>,
-    logged_account: LoggedAccount,
+    logged_account: RetrievedAccount,
     product_id: web::Path<String>,
     multipart: Multipart,
 ) -> ServiceResult<HttpResponse> {
-    login_required!(logged_account);
+    let logged_account = login_required!(logged_account);
 
     let conn = &pool.get()?;
     let mut product = Product::get(&conn, &Uuid::parse_str(&product_id)?)?;

--- a/src/web/products.rs
+++ b/src/web/products.rs
@@ -2,7 +2,7 @@ use crate::core::{
     Category, DbConnection, Money, Pool, Product, Searchable, ServiceError, ServiceResult,
 };
 use crate::login_required;
-use crate::web::identity_policy::{LoggedAccount, RetrievedAccount};
+use crate::web::identity_policy::{RetrievedAccount};
 use crate::web::utils::{HbData, Search};
 use actix_multipart::Multipart;
 use actix_web::{http, web, HttpRequest, HttpResponse};
@@ -93,7 +93,7 @@ pub async fn post_product_edit(
     product: web::Form<FormProduct>,
     product_id: web::Path<String>,
 ) -> ServiceResult<HttpResponse> {
-    let logged_account = login_required!(logged_account);
+    let _logged_account = login_required!(logged_account);
 
     if *product_id != product.id {
         return Err(ServiceError::BadRequest(
@@ -168,7 +168,7 @@ pub async fn post_product_create(
     pool: web::Data<Pool>,
     product: web::Form<FormProduct>,
 ) -> ServiceResult<HttpResponse> {
-    let logged_account = login_required!(logged_account);
+    let _logged_account = login_required!(logged_account);
 
     let conn = &pool.get()?;
 
@@ -202,7 +202,7 @@ pub async fn get_product_delete(
     logged_account: RetrievedAccount,
     _product_id: web::Path<String>,
 ) -> ServiceResult<HttpResponse> {
-    let logged_account = login_required!(logged_account);
+    let _logged_account = login_required!(logged_account);
 
     println!("Delete is not supported!");
 
@@ -217,7 +217,7 @@ pub async fn get_product_remove_image(
     logged_account: RetrievedAccount,
     product_id: web::Path<String>,
 ) -> ServiceResult<HttpResponse> {
-    let logged_account = login_required!(logged_account);
+    let _logged_account = login_required!(logged_account);
 
     let conn = &pool.get()?;
 
@@ -237,7 +237,7 @@ pub async fn post_product_upload_image(
     product_id: web::Path<String>,
     multipart: Multipart,
 ) -> ServiceResult<HttpResponse> {
-    let logged_account = login_required!(logged_account);
+    let _logged_account = login_required!(logged_account);
 
     let conn = &pool.get()?;
     let mut product = Product::get(&conn, &Uuid::parse_str(&product_id)?)?;

--- a/src/web/products.rs
+++ b/src/web/products.rs
@@ -2,7 +2,7 @@ use crate::core::{
     Category, DbConnection, Money, Pool, Product, Searchable, ServiceError, ServiceResult,
 };
 use crate::login_required;
-use crate::web::identity_policy::{RetrievedAccount};
+use crate::web::identity_policy::RetrievedAccount;
 use crate::web::utils::{HbData, Search};
 use actix_multipart::Multipart;
 use actix_web::{http, web, HttpRequest, HttpResponse};

--- a/src/web/transactions.rs
+++ b/src/web/transactions.rs
@@ -1,6 +1,6 @@
 use crate::core::{transactions, Account, Money, Pool, ServiceResult};
 use crate::login_required;
-use crate::web::identity_policy::{LoggedAccount, RetrievedAccount};
+use crate::web::identity_policy::{RetrievedAccount};
 use crate::web::utils::HbData;
 use actix_web::{http, web, HttpRequest, HttpResponse};
 use chrono::{Duration, Local, NaiveDateTime};

--- a/src/web/transactions.rs
+++ b/src/web/transactions.rs
@@ -1,6 +1,6 @@
 use crate::core::{transactions, Account, Money, Pool, ServiceResult};
 use crate::login_required;
-use crate::web::identity_policy::LoggedAccount;
+use crate::web::identity_policy::{LoggedAccount, RetrievedAccount};
 use crate::web::utils::HbData;
 use actix_web::{http, web, HttpRequest, HttpResponse};
 use chrono::{Duration, Local, NaiveDateTime};
@@ -33,12 +33,12 @@ pub struct Execute {
 pub async fn get_transactions(
     pool: web::Data<Pool>,
     hb: web::Data<Handlebars>,
-    logged_account: LoggedAccount,
+    logged_account: RetrievedAccount,
     account_id: web::Path<String>,
     query: web::Query<FromToQuery>,
     request: HttpRequest,
 ) -> ServiceResult<HttpResponse> {
-    login_required!(logged_account);
+    let logged_account = login_required!(logged_account);
 
     let conn = &pool.get()?;
 
@@ -74,11 +74,11 @@ pub async fn get_transactions(
 /// GET route for `/transaction/execute/{account_id}`
 pub async fn post_execute_transaction(
     pool: web::Data<Pool>,
-    logged_account: LoggedAccount,
+    logged_account: RetrievedAccount,
     account_id: web::Path<String>,
     execute_form: web::Form<Execute>,
 ) -> ServiceResult<HttpResponse> {
-    login_required!(logged_account);
+    let logged_account = login_required!(logged_account);
 
     if execute_form.total != 0.0 {
         let conn = &pool.get()?;

--- a/src/web/transactions.rs
+++ b/src/web/transactions.rs
@@ -1,6 +1,6 @@
 use crate::core::{transactions, Account, Money, Pool, ServiceResult};
 use crate::login_required;
-use crate::web::identity_policy::{RetrievedAccount};
+use crate::web::identity_policy::RetrievedAccount;
 use crate::web::utils::HbData;
 use actix_web::{http, web, HttpRequest, HttpResponse};
 use chrono::{Duration, Local, NaiveDateTime};

--- a/src/web/transactions.rs
+++ b/src/web/transactions.rs
@@ -1,10 +1,10 @@
+use crate::core::{transactions, Account, Money, Pool, ServiceResult};
+use crate::login_required;
+use crate::web::identity_policy::LoggedAccount;
+use crate::web::utils::HbData;
 use actix_web::{http, web, HttpRequest, HttpResponse};
 use chrono::{Duration, Local, NaiveDateTime};
 use handlebars::Handlebars;
-
-use crate::core::{transactions, Account, Money, Pool, ServiceResult};
-use crate::web::identity_policy::LoggedAccount;
-use crate::web::utils::HbData;
 
 use uuid::Uuid;
 
@@ -38,7 +38,7 @@ pub async fn get_transactions(
     query: web::Query<FromToQuery>,
     request: HttpRequest,
 ) -> ServiceResult<HttpResponse> {
-    logged_account.require_member()?;
+    login_required!(logged_account);
 
     let conn = &pool.get()?;
 
@@ -78,7 +78,7 @@ pub async fn post_execute_transaction(
     account_id: web::Path<String>,
     execute_form: web::Form<Execute>,
 ) -> ServiceResult<HttpResponse> {
-    logged_account.require_member()?;
+    login_required!(logged_account);
 
     if execute_form.total != 0.0 {
         let conn = &pool.get()?;

--- a/src/web/utils.rs
+++ b/src/web/utils.rs
@@ -7,7 +7,7 @@ use serde::ser::Serialize;
 use serde_json::value::Value;
 
 use crate::core::Account;
-use crate::web::identity_policy::LoggedAccount;
+use crate::web::identity_policy::{LoggedAccount, RetrievedAccount};
 
 /// Helper to convert empty strings to `None` values
 pub trait EmptyToNone<T> {

--- a/src/web/utils.rs
+++ b/src/web/utils.rs
@@ -7,7 +7,7 @@ use serde::ser::Serialize;
 use serde_json::value::Value;
 
 use crate::core::Account;
-use crate::web::identity_policy::{LoggedAccount};
+use crate::web::identity_policy::LoggedAccount;
 
 /// Helper to convert empty strings to `None` values
 pub trait EmptyToNone<T> {

--- a/src/web/utils.rs
+++ b/src/web/utils.rs
@@ -7,7 +7,7 @@ use serde::ser::Serialize;
 use serde_json::value::Value;
 
 use crate::core::Account;
-use crate::web::identity_policy::{LoggedAccount, RetrievedAccount};
+use crate::web::identity_policy::{LoggedAccount};
 
 /// Helper to convert empty strings to `None` values
 pub trait EmptyToNone<T> {


### PR DESCRIPTION
This PR will close #11. Please review this and check, if it works correctly.

The PR introduces the `login_required!` and `admin_required!` macros that implicitly unwrap the data retrieved in the middleware. I sadly had to wrap the `LoggedAccount` data structure in an enum to make the magic work. But in combination with the macros, this is taken care of implicitly.

There are still two *TODO*s in the code that have to be taken care of, as marked in the code. One of these things is the correct handling of the _unauthorized_ state. Additionally, we may have to clean up the `Error` type(?).